### PR TITLE
replace deprecated tar.gz module with tar module

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -11,10 +11,7 @@ var fsp = require("fs-promise");
 var got = require("got");
 var mkdirp = require("mkdirp-promise");
 var path = require("path");
-
-// TODO: this lib takes 0.5s to load! Must be replaced asap.
-// Perhaps just use the unix `tar` command (cross platform?)
-var targz = require("tar.gz");
+var tar = require("tar");
 
 // String -> String ~> Promise String
 //   Downloads a file from an url to a path.
@@ -92,7 +89,10 @@ var downloadAndCheck = function downloadAndCheck(url) {
 //   TODO: work for zip and other types
 var extract = function extract(fromPath) {
   return function (toPath) {
-    return targz().extract(fromPath, toPath).then(function () {
+    return tar.extract({
+        file: fromPath,
+        cwd: toPath
+    }).then(function () {
       return toPath;
     });
   };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mkdirp-promise": "^5.0.1",
     "mock-fs": "^4.1.0",
     "setimmediate": "^1.0.5",
-    "tar.gz": "^1.0.5",
+    "tar": "^4.0.2",
     "xhr-request-promise": "^0.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
fixes #10 

I ran the test for this.

```
> let test = require('./lib/files.js').test
> test().then(console.log)
// true
```

Looks good :) 