### PR TITLE
Updated got version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "buffer": "^5.0.5",
     "eth-lib": "^0.1.26",
     "fs-extra": "^4.0.2",
-    "got": "^7.1.0",
+    "got": "^8.0.0",
     "mime-types": "^2.1.16",
     "mkdirp-promise": "^5.0.1",
     "mock-fs": "^4.1.0",


### PR DESCRIPTION
got npm package needs to be updated to version 8. This version contains a bug that is causing Angular universal SSR build failure. In version 7 got is trying to require package.json file using the below command without .json extension.
const pkg = require('./package');
In version 8 this issues is resolved.